### PR TITLE
added @babel/core to package.json to be able to run the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"build": "echo TODO 😅"
 	},
 	"dependencies": {
+		"@babel/core": "^7.16.0",
 		"clsx": "^1.1.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"


### PR DESCRIPTION
I was unable to run the project unless I had `@bable/core` installed. I went ahead and installed that as a dependency in this PR. I believe it's the same for the `final` branch so I'm going to do a PR there as well. 